### PR TITLE
Fix python error when slackNotification is false

### DIFF
--- a/terraform/ecs/provision/restarts.tf
+++ b/terraform/ecs/provision/restarts.tf
@@ -90,7 +90,7 @@ resource "local_file" "app" {
 
 resource "local_file" "app_no_slack" {
   count = var.slackNotification ? 0 : 1
-  content  = replace(local.app_template, "notifySlack(message_json, service_dimensions['ClusterName'], service_dimensions['ServiceName'])", "")
+  content  = replace(local.app_template, "notifySlack(message_json, service_dimensions['ClusterName'], service_dimensions['ServiceName'])", "pass")
   filename = "${path.module}/app.py"
 }
 


### PR DESCRIPTION
The setup for when `slackNotification` is `false` removes a couple of lines in a python function, but this was actually making malformed python code when it removed the only line in an indented block. This changes the string replacement so it won't cause an error.